### PR TITLE
Dev: update auto_ftp

### DIFF
--- a/RLA/auto_ftp.py
+++ b/RLA/auto_ftp.py
@@ -197,13 +197,14 @@ class SFTPHandler(FTPHandler):
         self.close()
 
     def download_file(self, remote_file, local_file):
+        self.sftp = self.sftpconnect()
         logger.info("try download {}".format(local_file))
         if not os.path.isfile(local_file):
             logger.info("new file {}".format(local_file))
-            self.sftp.get(remote_file)
+            self.sftp.get(remote_file, local_file)
         elif self.sftp.stat(remote_file).st_size != os.path.getsize(local_file):
             logger.info("update file {}".format(local_file))
-            self.sftp.get(remote_file)
+            self.sftp.get(remote_file, local_file)
         else:
             logger.info("skip download file {}".format(remote_file))
 

--- a/RLA/easy_log/tester.py
+++ b/RLA/easy_log/tester.py
@@ -313,16 +313,17 @@ class Tester(object):
             from RLA.auto_ftp import FTPHandler
             from RLA.auto_ftp import SFTPHandler
             try:
-                try:
-                    ftp = FTPHandler(ftp_server=self.private_config["REMOTE_SETTING"]["ftp_server"],
-                                    username=self.private_config["REMOTE_SETTING"]["username"],
-                                    password=self.private_config["REMOTE_SETTING"]["password"])
-                except Exception as e:
-                    logger.warn("sending log file failed. {}".format(e))
-                    logger.warn("try to send log file through sftp")
+                if 'file_transfer_protocol' not in self.private_config["REMOTE_SETTING"].keys() or self.private_config["REMOTE_SETTING"]['file_transfer_protocol'] is 'sftp':
                     ftp = SFTPHandler(sftp_server=self.private_config["REMOTE_SETTING"]["ftp_server"],
                                             username=self.private_config["REMOTE_SETTING"]["username"],
                                             password=self.private_config["REMOTE_SETTING"]["password"])
+                elif self.private_config["REMOTE_SETTING"]['file_transfer_protocol'] is 'ftp':
+                    ftp = FTPHandler(ftp_server=self.private_config["REMOTE_SETTING"]["ftp_server"],
+                                    username=self.private_config["REMOTE_SETTING"]["username"],
+                                    password=self.private_config["REMOTE_SETTING"]["password"])
+                else:
+                    raise ValueError("designated file_transfer_protocol {} is not supported".format(self.private_config["REMOTE_SETTING"]['file_transfer_protocol']))
+                    
                 for root, dirs, files in os.walk(self.log_dir):
                     suffix = root.split("/{}/".format(LOG))
                     assert len(suffix) == 2, "root should only have one pattern \"/log/\""

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -1,7 +1,9 @@
 from test._base import BaseTest
 from RLA.easy_log.log_tools import DeleteLogTool, Filter
 from RLA.easy_log.log_tools import ArchiveLogTool, ViewLogTool
-
+from RLA.easy_log.tester import exp_manager
+from RLA.auto_ftp import SFTPHandler
+import os
 
 class ScriptTest(BaseTest):
 
@@ -56,3 +58,13 @@ class ScriptTest(BaseTest):
         self.remove_and_copy_data()
         dlt = ViewLogTool(proj_root=self.TARGET_DATA_ROOT, task_table_name=self.TASK_NAME, regex='2022/03/01/21-13*')
         dlt.view_log(skip_ask=True)
+
+    def test_sync_log(self):
+        exp_manager.configure(task_name='test',
+                     private_config_path='./test/test_data_root/rla_config.yaml',
+                     log_root='./test/test_data_root/source/')
+        ftp = SFTPHandler(sftp_server=exp_manager.private_config["REMOTE_SETTING"]["ftp_server"],
+                             username=exp_manager.private_config["REMOTE_SETTING"]["username"],
+                             password=exp_manager.private_config["REMOTE_SETTING"]["password"])
+        ftp.upload_file(os.getcwd() + '/' + 'test/test_data_root/target/', 'test/test_data_root/source/', 'test.txt')
+        ftp.download_file(os.getcwd() + '/' + 'test/test_data_root/source/download.txt', 'test/test_data_root/target/download.txt')


### PR DESCRIPTION
to set
REMOTE_SETTING:
  file_transfer_protocol: 'sftp'
to choose sftp or ftp for sync logs. 

If not designated, use sftp by default.
 
Add unit test for 'upload_file' and 'download_file' for sftp (SFTPHandler in RLA/auto_ftp.py). 